### PR TITLE
fix(warning): fixes a warning message in read_nircal()

### DIFF
--- a/R/read_nircal.R
+++ b/R/read_nircal.R
@@ -633,7 +633,7 @@ get_nircal_response <- function(x, n) {
 
 
   if (sum(duplicated(property_names)) > 0) {
-    wnr <- c("Some property names are duplicated, please correct the names. Indices have been added to the repeated names")
+    wrn <- c("Some property names are duplicated, please correct the names. Indices have been added to the repeated names")
     dpn <- unique(property_names[duplicated(property_names)])
     for (i in 1:length(dpn)) {
       property_names[property_names == dpn] <- paste(property_names[property_names == dpn],


### PR DESCRIPTION
a message about repeated property names was not being passed properly to the output of the function