### PR TITLE
`prospectr::duplex()`: Avoid error "1:nrow(d) : argument of length 0" when `2 * k` is `nrow(X)`.

### DIFF
--- a/R/duplex.R
+++ b/R/duplex.R
@@ -129,7 +129,7 @@ duplex <- function(X,
   }
 
   m <- nrow(X)
-  n <- seq_along(X)
+  n <- seq_len(nrow(X))
   half <- floor(m / 2)
   if (k > half) {
     k <- half
@@ -174,10 +174,10 @@ duplex <- function(X,
     # cal
     if (i == ini) {
       d <- D[model, -c(model, test), drop = FALSE]
-      mins_cal <- do.call(pmin.int, lapply(seq_along(d), function(i) d[i, ]))
+      mins_cal <- do.call(pmin.int, lapply(seq_len(nrow(d)), function(i) d[i, ]))
     } else {
       d <- rbind(D[nid_cal, -c(model, test), drop = FALSE], mins_cal)
-      mins_cal <- do.call(pmin.int, lapply(seq_along(d), function(i) d[i, ]))
+      mins_cal <- do.call(pmin.int, lapply(seq_len(nrow(d)), function(i) d[i, ]))
     }
 
     id <- which.max(mins_cal)
@@ -199,10 +199,10 @@ duplex <- function(X,
     # test
     if (i == ini) {
       d <- D[test, -c(model, test), drop = FALSE]
-      mins_val <- do.call(pmin.int, lapply(seq_along(d), function(i) d[i, ]))
+      mins_val <- do.call(pmin.int, lapply(seq_len(nrow(d)), function(i) d[i, ]))
     } else {
       d <- rbind(D[nid_val, -c(model, test), drop = FALSE], mins_val)
-      mins_val <- do.call(pmin.int, lapply(seq_along(d), function(i) d[i, ]))
+      mins_val <- do.call(pmin.int, lapply(seq_len(row(d)), function(i) d[i, ]))
     }
 
     id <- which.max(mins_val)

--- a/R/duplex.R
+++ b/R/duplex.R
@@ -114,7 +114,7 @@ duplex <- function(X,
         pc <- 1
       }
     }
-    scores <- X <- pca$x[, 1:pc, drop = F]
+    scores <- X <- pca$x[, 1:pc, drop = FALSE]
   }
 
   if (metric == "mahal") {

--- a/R/duplex.R
+++ b/R/duplex.R
@@ -158,7 +158,19 @@ duplex <- function(X,
   n <- n[-id]
 
   # Another two most distant points to test set
-  id <- c(arrayInd(which.max(D[, -id]), rep(m - 2, 2)))
+  d <- D[, -id] # remaining after first model set assignment
+  if (ncol(d) == 2L) {
+    # if only two samples left in test (nrow(X) == 4), assign both to test;
+    # avoids returning twice the same sample for test
+    test <- n
+    if (missing(pc)) {
+      return(list(model = model, test = test))
+    } else {
+      return(list(model = model, test = test, pc = scores))
+    }
+  } else {
+    id <- c(arrayInd(which.max(d), rep(m - 2, 2)))
+  }
 
   if (!missing(group)) {
     id <- which(group %in% group[id])

--- a/R/duplex.R
+++ b/R/duplex.R
@@ -99,6 +99,9 @@ duplex <- function(X,
   if (k < 2) {
     stop("Invalid argument: 'k' must be higher than 2")
   }
+  if (2 * k > nrow(X)) {
+    stop("'k' must be smaller than 'nrow(X) / 2'")
+  }
   metric <- match.arg(metric)
   if (is.data.frame(X)) {
     x <- X <- as.matrix(X)

--- a/R/duplex.R
+++ b/R/duplex.R
@@ -170,10 +170,10 @@ duplex <- function(X,
   while (i < k) {
     # cal
     if (i == ini) {
-      d <- D[model, -c(model, test)]
+      d <- D[model, -c(model, test), drop = FALSE]
       mins_cal <- do.call(pmin.int, lapply(1:nrow(d), function(i) d[i, ]))
     } else {
-      d <- rbind(D[nid_cal, -c(model, test)], mins_cal)
+      d <- rbind(D[nid_cal, -c(model, test), drop = FALSE], mins_cal)
       mins_cal <- do.call(pmin.int, lapply(1:nrow(d), function(i) d[i, ]))
     }
 
@@ -195,10 +195,10 @@ duplex <- function(X,
 
     # test
     if (i == ini) {
-      d <- D[test, -c(model, test)]
+      d <- D[test, -c(model, test), drop = FALSE]
       mins_val <- do.call(pmin.int, lapply(1:nrow(d), function(i) d[i, ]))
     } else {
-      d <- rbind(D[nid_val, -c(model, test)], mins_val)
+      d <- rbind(D[nid_val, -c(model, test), drop = FALSE], mins_val)
       mins_val <- do.call(pmin.int, lapply(1:nrow(d), function(i) d[i, ]))
     }
 

--- a/R/duplex.R
+++ b/R/duplex.R
@@ -129,7 +129,7 @@ duplex <- function(X,
   }
 
   m <- nrow(X)
-  n <- 1:nrow(X)
+  n <- seq_along(X)
   half <- floor(m / 2)
   if (k > half) {
     k <- half
@@ -174,10 +174,10 @@ duplex <- function(X,
     # cal
     if (i == ini) {
       d <- D[model, -c(model, test), drop = FALSE]
-      mins_cal <- do.call(pmin.int, lapply(1:nrow(d), function(i) d[i, ]))
+      mins_cal <- do.call(pmin.int, lapply(seq_along(d), function(i) d[i, ]))
     } else {
       d <- rbind(D[nid_cal, -c(model, test), drop = FALSE], mins_cal)
-      mins_cal <- do.call(pmin.int, lapply(1:nrow(d), function(i) d[i, ]))
+      mins_cal <- do.call(pmin.int, lapply(seq_along(d), function(i) d[i, ]))
     }
 
     id <- which.max(mins_cal)
@@ -199,10 +199,10 @@ duplex <- function(X,
     # test
     if (i == ini) {
       d <- D[test, -c(model, test), drop = FALSE]
-      mins_val <- do.call(pmin.int, lapply(1:nrow(d), function(i) d[i, ]))
+      mins_val <- do.call(pmin.int, lapply(seq_along(d), function(i) d[i, ]))
     } else {
       d <- rbind(D[nid_val, -c(model, test), drop = FALSE], mins_val)
-      mins_val <- do.call(pmin.int, lapply(1:nrow(d), function(i) d[i, ]))
+      mins_val <- do.call(pmin.int, lapply(seq_along(d), function(i) d[i, ]))
     }
 
     id <- which.max(mins_val)


### PR DESCRIPTION
While working on a cLHS-DUPLEX sampling problem within clusters, I encountered an unlikely but unlucky case that threw an error (see next message). Because I first select spectra that are representative in terms of the distributions of spectral variables --- subject to reference analysis via conditioned latin hypercube sampling --- the next DUPLEX step decides for calibration/tuning or validation. Here, there is the situation of `ntot_cluster_ref = 2 * k_duplex_fun`. Meaning that half of the pool of spectra to be subjected to reference analysis at this stage go to calibration and half to validation roles, so that if run DUPLEX successfully in the end there is no spectra left.

However, for some edge cases, if there is only 1 possible sample left for "test" in the `while (i < k)` conditional, "Error in 1:nrow(d) : argument of length 0" occurs. This is because `1:nrow(d)` is called after when `d` results in a 2L vector instead of a matrix expected, e.g. because of the implicit `drop = TRUE` default in `[` for matrices/dfs. To be on the safe side, this PR both explicitly does not drop any dims when removing previously assigned samples via `drop = FALSE` and replaces `1:nrow(d)` with `seq_len(nrow(d))`. The commits in this branch try to avoid any unintended side effects.