### PR TITLE
Fixed DUPLEX implementation

### DIFF
--- a/R/duplex.R
+++ b/R/duplex.R
@@ -158,7 +158,7 @@ duplex <- function(X,
   n <- n[-id]
 
   # Another two most distant points to test set
-  d <- D[, -id] # remaining after first model set assignment
+  d <- D[-id, -id] # remaining after first model set assignment
   if (ncol(d) == 2L) {
     # if only two samples left in test (nrow(X) == 4), assign both to test;
     # avoids returning twice the same sample for test


### PR DESCRIPTION
Selecting the 2nd set of most distant points was wrong. D is a symmetric matrix, but the code was removing the columns ONLY (corresponding to the first two most distant points). But it should be removing the columns AND rows corresponding to the first two most distant points.

To test this, try running DUPLEX on the following data:

	[1,1],
	[1,2],
	[2,2],
	[2,1],
	[1.5,1.5],
	[1.6,1.5],

When it's working properly, it should select 2 corner points for the first most distant points, and 2 other corner points for the 2nd most distant points, but current implementation doesn't; it picks a point from the middle instead, as shown in the picture below:

![image](https://user-images.githubusercontent.com/4992373/223337759-9823b2a7-92d7-46d9-a98d-5b35d9f59565.png)

I have edited the code such that it removes both rows and columns. This fixes the problem.