### PR TITLE
gapDir Accept vector input

### DIFF
--- a/R/gapDer.R
+++ b/R/gapDer.R
@@ -132,15 +132,6 @@ gapDer <- function(X, m = 1, w = 1, s = 1, delta.wav) {
     rownames(output) <- rownames(X)
   }
 
-  if (is.vector(X)) {
-    if (w >= length(X)) {
-      stop("filter length w must be lower than length(X)")
-    }
-    output <- convCppV(X, sg_filter) # Convolution
-    g <- (w - 1) / 2
-    names(output) <- names(X)[((g + 1):(length(X) - g))]
-  }
-
   if (!missing(delta.wav)) {
     output <- output / delta.wav^m
   }

--- a/R/gapDer.R
+++ b/R/gapDer.R
@@ -82,13 +82,17 @@ gapDer <- function(X, m = 1, w = 1, s = 1, delta.wav) {
 
   filter_length <- m * w + (m + 1) * s
 
+  if (is.data.frame(X)) {
+    X <- as.matrix(X)
+  } else if (is.vector(X)) {
+    X <- matrix(X, nrow = 1)
+  }
+  
   if (filter_length > ncol(X)) {
     stop("the current parameters produce a filter with a length larger than the number of variables in X")
   }
 
-  if (is.data.frame(X)) {
-    X <- as.matrix(X)
-  }
+
 
   zw <- rep(0, w)
   os <- rep(1, s)

--- a/tests/testthat/test-gapDer.R
+++ b/tests/testthat/test-gapDer.R
@@ -8,7 +8,7 @@ test_that("gapDer works", {
   expect_is(X_gapDer, "matrix")
   expect_true(round(max(abs(X_gapDer[1, ])), 5) == 0.00517)
   
-  X_gapDer <- gapDer(NIRsoil$spc[1,], m = 1, w = 3)
-  expect_is(X_gapDer, "matrix")
-  expect_true(round(max(abs(X_gapDer[1, ])), 5) == 0.00517)
+  X_gapDer_vec <- gapDer(NIRsoil$spc[1,], m = 1, w = 3)
+  expect_is(X_gapDer_vec, "matrix")
+  expect_true(round(max(abs(X_gapDer_vec[1, ])), 5) == 0.00517)
 })

--- a/tests/testthat/test-gapDer.R
+++ b/tests/testthat/test-gapDer.R
@@ -7,4 +7,8 @@ test_that("gapDer works", {
 
   expect_is(X_gapDer, "matrix")
   expect_true(round(max(abs(X_gapDer[1, ])), 5) == 0.00517)
+  
+  X_gapDer <- gapDer(NIRsoil$spc[1,], m = 1, w = 3)
+  expect_is(X_gapDer, "matrix")
+  expect_true(round(max(abs(X_gapDer[1, ])), 5) == 0.00517)
 })


### PR DESCRIPTION
The docs said that `gapDir()` could accept vector input, but this didn't work. Find a solution here (mostly just convert vectors to a 1-row matrix, and test/code cleanup).