### PR TITLE
fix(read_nircal): id substring

### DIFF
--- a/R/read_nircal.R
+++ b/R/read_nircal.R
@@ -405,7 +405,7 @@ get_nircal_ids <- function(connection, from, to) {
   # ids <- iconv(ids, to = "UTF-8", sub = NA)
   ids2 <- ids[-c(1, length(ids))]
 
-  ids <- try(substr(x = ids2, start = regexpr("/", ids) + 1, stop = 100000))
+  ids <- try(substr(x = ids2, start = regexpr("/", ids2) + 1, stop = 100000))
   if (inherits(ids, "try-error")) {
     ids <- iconv(ids2, from = "Latin1", to = "UTF-8")
   }

--- a/R/read_nircal.R
+++ b/R/read_nircal.R
@@ -405,7 +405,7 @@ get_nircal_ids <- function(connection, from, to) {
   # ids <- iconv(ids, to = "UTF-8", sub = NA)
   ids2 <- ids[-c(1, length(ids))]
 
-  ids <- try(substr(x = ids2, start = regexpr("/", ids2) + 1, stop = 100000))
+  ids <- try(substr(x = ids2, start = regexpr("/", ids2) + 1, stop = nchar(ids2)))
   if (inherits(ids, "try-error")) {
     ids <- iconv(ids2, from = "Latin1", to = "UTF-8")
   }


### PR DESCRIPTION
This PR resolves the following issue:

In `read_nircal`, when reading the IDs, we take the substring of the IDs after the slash character. However, the start position when taking the substring was taken with respect to `ids`, whereas the substrings are taken over `ids2`. 

However, the two vectors have differing lengths. This means that the start of the substring was taken with respect to the ID of the element before it.

This is noticeable when the ID of the samples have a different number of digits before the slash character, e.g. for `c("10/12345", "1/1")`. The current approach would return IDs `c("12345", "")`. The proposed fix would return `c("12345", "1")` instead.