### PR TITLE
V0.2.10

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,14 @@
+`prospectr 0.2.10 (zurich)`
+===============
+
+### Features:
+
+* `detrend()`: New `method` argument to allow polynomial detrending without a 
+prior SNV transformation. The default behaviour is unchanged and remains 
+consistent with Barnes et al. (1989). Set `method = "poly"` to apply pure 
+polynomial detrending independently of SNV, for example as a separate step 
+in a pre-processing pipeline.
+
 `prospectr 0.2.9 (proxy)`
 ===============
 

--- a/R/detrend.R
+++ b/R/detrend.R
@@ -5,7 +5,7 @@
 #' Optionally, an SNV transformation is applied prior to fitting, as prescribed
 #' by Barnes et al. (1989).
 #' @usage
-#' detrend(X, wav, p = 2, snv = TRUE, method = "poly")
+#' detrend(X, wav, p = 2, snv = TRUE, method = c("poly", "raw"))
 #' @param X a numeric matrix or vector to process (optionally a data frame that
 #' can be coerced to a numerical matrix)
 #' @param wav the wavelengths/ band centers.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ status](https://www.r-pkg.org/badges/version/prospectr?v=2.png)](https://CRAN.R-
 [![Downloads](https://cranlogs.r-pkg.org/badges/grand-total/prospectr?v=2.png)](https://CRAN.R-project.org/package=prospectr)  
 <!-- badges: end -->
 
-<img align="right" src="./man/figures/logo.png" width="15%">
+<img align="right" src="./man/figures/logo.png" width="15%" alt="prospectr logo">
 
 *Last update: 2026-06-22*
 

--- a/README.qmd
+++ b/README.qmd
@@ -16,7 +16,7 @@ engine: knitr
 [![Downloads](https://cranlogs.r-pkg.org/badges/grand-total/prospectr?v=2)](https://CRAN.R-project.org/package=prospectr)  
 <!-- badges: end -->
 
-<img align="right" src="./man/figures/logo.png" width="15%">  
+<img align="right" src="./man/figures/logo.png" width="15%" alt="prospectr logo">
 
 _Last update: `r Sys.Date()`_
 

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -16,6 +16,7 @@ navbar:
     github:
       icon: fab fa-github
       href: https://github.com/l-ramirez-lopez/prospectr
+      aria-label: "GitHub repository"
 
 logo:
   image: logo.jpg

--- a/man/detrend.Rd
+++ b/man/detrend.Rd
@@ -4,7 +4,7 @@
 \alias{detrend}
 \title{Detrending spectral data}
 \usage{
-detrend(X, wav, p = 2, snv = TRUE, method = "poly")
+detrend(X, wav, p = 2, snv = TRUE, method = c("poly", "raw"))
 }
 \arguments{
 \item{X}{a numeric matrix or vector to process (optionally a data frame that

--- a/my-comments.md
+++ b/my-comments.md
@@ -1,4 +1,68 @@
 # prospectr
+# version 0.2.10
+
+## Cover letter
+
+Dear CRAN maintainers,
+
+I am submitting version 0.2.10 of the `prospectr` package. This release
+focuses on a new argument for the `detrend()` function which allows polynomial 
+detrending without a prior SNV transformation. 
+
+The tarball has been checked on R-winbuilder (R-release and R-devel).
+Reverse dependencies have been checked and are unaffected.
+
+Best regards,
+Leonardo
+
+---
+
+## Package build
+
+```r
+pkgbuild::build(
+  path = ".",
+  dest_path = "..",
+  binary = FALSE,
+  vignettes = TRUE,
+  manual = FALSE,
+  quiet = FALSE
+)
+```
+
+Locally has been tested in Ubuntu:
+
+```
+devtools::check(
+  args = "--as-cran",
+  env_vars = c(
+    `_R_CHECK_CRAN_INCOMING_` = "true",
+    `_R_CHECK_CRAN_INCOMING_REMOTE_` = "true"
+  )
+)
+```
+
+---
+
+## Test environments
+
+### Local
+- Ubuntu 24.04, R 4.5.0 (release)
+
+### GitHub Actions (all passing)
+- ubuntu-latest, R release
+- ubuntu-latest, R devel
+- windows-latest, R release
+- macos-latest, R release
+
+### R-winbuilder
+- Windows Server 2022, R-release — OK (no ERRORs, no WARNINGs, 1 NOTE: installed
+  package size, data/libs subdirectories — pre-existing, not introduced by this release)
+- Windows Server 2022, R-devel   — OK (same NOTE as above)
+
+---
+
+# prospectr
 # version 0.2.9
 
 ## Cover letter


### PR DESCRIPTION
In this version `detrend()` gets a new `method` argument to allow polynomial detrending without a prior SNV transformation. The default behaviour is unchanged and remains consistent with Barnes et al. (1989). Set `method = "poly"` to apply pure polynomial detrending independently of SNV, for example as a separate step in a pre-processing pipeline.